### PR TITLE
Add general purpose log rotation capability that works on windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([logr], [1.0.3])
+AC_INIT([logr], [1.0.4])
 AC_PREREQ([2.65])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 AM_PROG_AR

--- a/man/logr.7.in
+++ b/man/logr.7.in
@@ -23,6 +23,7 @@ logr \- customizable logging library for C/C++
 .B int logr_set_timestamp_format(logr_t *logr, char *fmt)
 
 .B int logr_set_threshold(logr_t *logr, off_t threshold);
+.B int logr_set_rotate_file_count(logr_t *logr, int max_files);
 
 .B int logr_printf(logr_t *logr, int log_level, char *format, ...);
 
@@ -311,9 +312,16 @@ By default, log files are not rotated -
 .B log_set_threshold()
 must be called to enable log file rotation.enable log file rotation.
 .PP
-Files are rotated and compressed by a child process using
-.B savelog(8)
-after the log files have reached their maximum threshold size.
+.nf
+
+int logr_set_rotate_file_count(logr_t *logr, int max_files);
+
+.fi
+.in
+You can set the maximum files to save on rotation by calling
+.B logr_set_rotate_file_count.
+The default is currently 7.
+
 .SH MULTIPLE LOGGERS
 You can have more than one logger in the same
 program,  for example, one that logs to
@@ -412,8 +420,6 @@ The
 .B logr
 functions generally return 0 on success and non-zero on failure.
 .SH SEE ALSO
-.B savelog(8)
-.PP
 The detailed API documention is available at:
 .in +4n
 

--- a/src/logr.h
+++ b/src/logr.h
@@ -59,6 +59,11 @@ extern "C" {
 #define LOGR_MAX_TIMESTAMP_SIZE 256
 
 /**
+ * Maximum number of files for rotation.
+ */
+#define LOGR_DEFAULT_MAX_FILE_ROTATE 7
+
+/**
  * Log levels.
  * Based on equivalent ones in syslog.h.
  * We define our own since syslog.h does not exist on windows.
@@ -239,6 +244,16 @@ typedef const char * (*logr_priority_func_t)(int);
     int logr_set_threshold(logr_t *logr, off_t threshold);
 
 /**
+ * Set the maximum number of files that should be rotated.
+ *
+ * \param logr The logr_t instance to use.
+ * \param max_files The maximum number of files to rotate.
+ * \returns 0 on success or -1 on error.
+ */
+
+    int logr_set_rotate_file_count(logr_t *logr, int max_files);
+
+/**
  * Format the timestamp according to the provided specification.
  *
  * The output format of the date can be set in the same manner as the
@@ -404,6 +419,16 @@ typedef const char * (*logr_priority_func_t)(int);
  * \returns 0 on success; -1 on error.
  */
     int logr_util_date(logr_t *logr, void *buf, size_t size);
+
+/**
+ * Utility function that returns a LOGR level when passed a LOGR name.
+ *
+ * \param level_name Level name for this message (.e.g. "debug" or "info")
+ * \returns int representation of <i>level_name</i>
+ * \returns -1 on error;
+ */
+    int logr_util_level(const char *level_name);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
and *nix, replacing the savelog(8) *nix solution.  Added:

```
int logr_set_rotate_file_count(logr_t *logr, int max_files);
```
